### PR TITLE
Fix persistant data with scenes

### DIFF
--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -58,21 +58,29 @@ func _count_playtime() -> void:
 
 func change_scene(path: String) -> void:
 	persistent_data["entered_from"] = get_tree().current_scene.scene_file_path
-
+	if persistent_data["entered_from"] == "":
+		persistent_data["entered_from"] = persistent_data["current_scene"]
+	
 	if persistent_data.has("scene_data"):
 		if persistent_data["scene_data"].has(path):
 			get_tree().change_scene_to_packed(persistent_data["scene_data"][path])
+			persistent_data["current_scene"] = path
+			return
 
 	get_tree().change_scene_to_file(path)
+	persistent_data["current_scene"] = path
 
 func save_current_scene() -> void:
 	var current_scene: Node = get_tree().current_scene
+	var scene_path = current_scene.scene_file_path
+	if scene_path == "":
+		scene_path = persistent_data["current_scene"]
 
 	if not persistent_data.has("scene_data"):
 		persistent_data["scene_data"] = {}
-
-		persistent_data["scene_data"][current_scene.scene_file_path] = PackedScene.new()
-		persistent_data["scene_data"][current_scene.scene_file_path].pack(current_scene)
+	
+	persistent_data["scene_data"][scene_path] = PackedScene.new()
+	persistent_data["scene_data"][scene_path].pack(current_scene)
 
 func save_player_data(player: YumePlayer, player_properties: Array[String] = ["accept_events", "cancel_events", "equipped_effect", "facing", "last_step", "name", "speed"]) -> void:
 	if player:


### PR DESCRIPTION
First. In the original script in game.gd, save_current_scene was only saving the scene data if persistent_data["scene_data"] didn't exist. So the only time a scene would save would be the first time save_current_scene() was called. For this I just removed the indenting after the first line in the if statement.

Then. Scenes with saved data still weren't getting loaded. Or actually they were getting loaded. However inside change_scene where it checks if the current scene being changed to has save data, it loads the scene but doesn't exit out of the function. Because of that the function keeps going and reaches: get_tree().change_scene_to_file(path). What ends up happening is the packed scene correctly gets loaded, but the another scene loads over it. I just threw in a return to fix that.

Then (again). Each scene would only save its data once, and then never again. This is because the way scenes were saved is by indexing persistent_data["scene_data"] by the scene nodes file path. The problem here is saved scenes are loaded with packed scenes via change_scene_to_packed(). When a packed scene is loaded, it doesn't retain its file path. To fix this I implemented a "current_scene" element in the persistent_data dictionary which just gets assigned every time a level is changed inside of change_scene()

Lastly because packed scenes don't retain their file paths, persistent_data["entered_from"] ended up being empty. Which was making Sakutsuki spawn beneath the bed after entering her dream room instead of spawning at the door. I just set persistent_data["entered_from"] to equal persistent_data["current_scene"] if the current scene is a packed scene.

All this ended up fixing the issue for me. After jumping between Nexus and Sakutsukis Dream Room the scenes seemed to persist.