### PR TITLE
YumeCharacter: Rework collision logic

### DIFF
--- a/scripts/ai/YumeCharacter/wanderer.gd
+++ b/scripts/ai/YumeCharacter/wanderer.gd
@@ -44,16 +44,16 @@ func _move_loop():
 		await waited
 
 		if not is_busy:
-			var can_move: bool = false
 			var picked_direction: Direction
 
-			while not (available_directions.is_empty() or can_move):
+			while not available_directions.is_empty():
 				picked_direction = available_directions.pick_random()
 
-				if is_colliding(picked_direction):
+				var offset_and_motion: PackedVector2Array = (
+						get_offset_and_motion(picked_direction))
+
+				if is_colliding(offset_and_motion):
 					available_directions.erase(picked_direction)
 				else:
-					can_move = true
-
-			if can_move:
-				move(picked_direction, false)
+					move(picked_direction, offset_and_motion, false)
+					break

--- a/scripts/ai/YumeHumanoid/wanderer.gd
+++ b/scripts/ai/YumeHumanoid/wanderer.gd
@@ -44,17 +44,17 @@ func _move_loop():
 		await waited
 
 		if not is_busy:
-			var can_move: bool = false
 			var picked_direction: Direction
 
-			while not (available_directions.is_empty() or can_move):
+			while not available_directions.is_empty():
 				picked_direction = available_directions.pick_random()
 
-				if is_colliding(picked_direction):
+				var offset_and_motion: PackedVector2Array = (
+						get_offset_and_motion(picked_direction))
+
+				if is_colliding(offset_and_motion):
 					available_directions.erase(picked_direction)
 				else:
-					can_move = true
-
-			if can_move:
-				facing = picked_direction
-				move(picked_direction, false)
+					facing = picked_direction
+					move(picked_direction, offset_and_motion, false)
+					break

--- a/scripts/characters/debugtsuki.gd
+++ b/scripts/characters/debugtsuki.gd
@@ -35,7 +35,8 @@ func _force_animation_update() -> void:
 
 	sprite.animation = Direction.find_key(facing).to_lower()
 
-func _move() -> void:
+
+func _move(motion: Vector2, ground_result: Dictionary) -> void:
 	var animation_name: StringName = Direction.find_key(facing).to_lower()
 
 	if last_step:
@@ -44,4 +45,4 @@ func _move() -> void:
 	animation_player.play(animation_name, -1.0, speed)
 	animation_player.seek(0.125)
 
-	await super()
+	await super(motion, ground_result)

--- a/scripts/characters/sakutsuki.gd
+++ b/scripts/characters/sakutsuki.gd
@@ -78,7 +78,8 @@ func _force_animation_update() -> void:
 
 	sprite.animation = Direction.find_key(facing).to_lower() + effect_name
 
-func _move() -> void:
+
+func _move(motion: Vector2, ground_result: Dictionary) -> void:
 	var animation_name: StringName = Effect.find_key(
 			equipped_effect).capitalize().path_join(
 			Direction.find_key(facing).to_lower())
@@ -89,7 +90,8 @@ func _move() -> void:
 	animation_player.play(animation_name, -1.0, speed)
 	animation_player.seek(0.125)
 
-	await super()
+	await super(motion, ground_result)
+
 
 ## Perform an action.
 func act() -> void:

--- a/scripts/classes/yume_character.gd
+++ b/scripts/classes/yume_character.gd
@@ -116,9 +116,9 @@ func collide_point(motion: Vector2, mask: int = collision_mask) -> Dictionary:
 		if current_world:
 			parameters.position = (current_world.wrap_around_world(
 					shape_owner.global_position + motion))
+
 		else:
-			parameters.position = (
-					shape_owner.global_position + motion)
+			parameters.position = shape_owner.global_position + motion
 
 		var result: Array[Dictionary] = space_state.intersect_point(
 				parameters, 1)
@@ -208,6 +208,19 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 
 				if network_collider:
 					return Dictionary({ "collider": network_collider })
+
+		else:
+			parameters.to = to
+			result = space_state.intersect_ray(parameters)
+
+			if result:
+				return result
+
+			network_collider = Game.collision_network.collide(
+					self, parameters.from, to)
+
+			if network_collider:
+				return Dictionary({ "collider": network_collider })
 
 	return {}
 

--- a/scripts/classes/yume_character.gd
+++ b/scripts/classes/yume_character.gd
@@ -56,10 +56,6 @@ var current_world: YumeWorld = null
 ## Direction the character is moving.
 var moving := Direction.NULL
 
-static var current_collisions: Array[CollisionShape2D] = []
-
-static var collisions_last_checked: int = 0
-
 ## Emitted when the character has moved.
 signal moved
 
@@ -83,48 +79,6 @@ func _notification(what: int) -> void:
 				if parent is YumeWorld:
 					current_world = parent
 					return
-
-
-func _get_current_collider(motion: Vector2) -> YumeCharacter:
-	var physics_frames: int = Engine.get_physics_frames()
-
-	if collisions_last_checked == physics_frames:
-		for current_collision_shape: CollisionShape2D in current_collisions:
-			var current_collision_shape_parent: YumeCharacter = \
-					current_collision_shape.get_parent()
-
-			if collision_mask & current_collision_shape_parent.collision_layer \
-					and not current_collision_shape.disabled:
-
-				for i: int in get_shape_owners():
-					var shape_owner: Object = shape_owner_get_owner(i)
-
-					var target_origin: Vector2 = (
-							current_world.wrap_around_world(
-							shape_owner.global_transform.origin + \
-							motion) - \
-							shape_owner.global_transform.origin \
-							if current_world else motion
-					)
-
-					var current_shape: Shape2D = current_collision_shape.shape
-					var target_transform := \
-							Transform2D(shape_owner.global_transform)
-
-					target_transform.origin += target_origin
-
-					if not shape_owner_get_shape(i, 0).collide_and_get_contacts(
-							target_transform,
-							current_shape,
-							current_collision_shape.global_transform) \
-							.is_empty():
-
-						return current_collision_shape_parent
-	else:
-		current_collisions.clear()
-		collisions_last_checked = physics_frames
-
-	return null
 
 
 func _move(motion: Vector2, ground_result: Dictionary) -> void:
@@ -189,6 +143,9 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 	var space_state: PhysicsDirectSpaceState2D = (
 			get_world_2d().direct_space_state)
 
+	var network_collider: CollisionObject2D = null
+	Game.collision_network.update()
+
 	# Check collisions for each collision shape individually.
 	for i: int in get_shape_owners():
 		var result: Dictionary = {}
@@ -214,6 +171,12 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 				if result:
 					return result
 
+				network_collider = Game.collision_network.collide(
+						self, parameters.from, parameters.to)
+
+				if network_collider:
+					return Dictionary({ "collider": network_collider })
+
 			# If ray is intersecting with bounds, break it down into two parts.
 			# First part: within bounds, second part: out of bounds. Then wrap
 			# the second part and check for collisions for each part.
@@ -224,6 +187,12 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 				if result:
 					return result
 
+				network_collider = Game.collision_network.collide(
+						self, parameters.from, parameters.to)
+
+				if network_collider:
+					return Dictionary({ "collider": network_collider })
+
 				# Hack for `@GlobalScope.wrap`'s `max` exclusiveness.
 				parameters.from = current_world.wrap_around_world(
 						intersection + motion) - motion
@@ -233,6 +202,12 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 
 				if result:
 					return result
+
+				network_collider = Game.collision_network.collide(
+						self, parameters.from, parameters.to)
+
+				if network_collider:
+					return Dictionary({ "collider": network_collider })
 
 	return {}
 
@@ -334,14 +309,11 @@ func move(direction: Direction,
 		elif not can_move_in_vacuum:
 			return
 
-		var current_collider: YumeCharacter = _get_current_collider(motion)
-
-		if current_collider:
-			current_collider.body_touched.emit(self)
-			return
+	else:
+		Game.collision_network.update()
 
 	for i: int in get_shape_owners():
-		current_collisions.append(shape_owner_get_owner(i))
+		Game.collision_network.peers.append(shape_owner_get_owner(i))
 
 	wrap_around_world(motion)
 	is_busy = true
@@ -356,14 +328,9 @@ func is_colliding(offset_and_motion: PackedVector2Array) -> bool:
 	if collide_ray(offset_and_motion):
 		return true
 
-	var motion: Vector2 = offset_and_motion[1]
-
 	if not can_move_in_vacuum:
-		if collide_point(motion, collision_mask >> 1):
+		if collide_point(offset_and_motion[1], collision_mask >> 1):
 			return true
-
-	if _get_current_collider(motion):
-		return true
 
 	return false
 

--- a/scripts/classes/yume_character.gd
+++ b/scripts/classes/yume_character.gd
@@ -56,13 +56,6 @@ var current_world: YumeWorld = null
 ## Direction the character is moving.
 var moving := Direction.NULL
 
-## Target movement point.
-var target_position: Vector2
-
-var surface_detector: RayCast2D = RayCast2D.new()
-
-var collision_detector: RayCast2D = RayCast2D.new()
-
 var collision_shapes: Array[CollisionShape2D] = []
 
 static var current_collisions: Array[CollisionShape2D] = []
@@ -87,18 +80,6 @@ func _init() -> void:
 	child_entered_tree.connect(on_child_entered_tree)
 	child_exiting_tree.connect(on_child_exiting_tree)
 
-	collision_detector.name = "CollisionDetector"
-	collision_detector.enabled = false
-	collision_detector.light_mask = 0
-	collision_detector.visibility_layer = 0
-
-	surface_detector.name = "SurfaceDetector"
-	surface_detector.enabled = false
-	surface_detector.light_mask = 0
-	surface_detector.visibility_layer = 0
-
-	add_child(collision_detector)
-	add_child(surface_detector)
 
 func _notification(what: int) -> void:
 	match what:
@@ -117,7 +98,8 @@ func _notification(what: int) -> void:
 					current_world = parent
 					return
 
-func _get_current_collider() -> YumeCharacter:
+
+func _get_current_collider(motion: Vector2) -> YumeCharacter:
 	var physics_frames: int = Engine.get_physics_frames()
 
 	if collisions_last_checked == physics_frames:
@@ -132,9 +114,9 @@ func _get_current_collider() -> YumeCharacter:
 					var target_origin: Vector2 = (
 							current_world.wrap_around_world(
 							collision_shape.global_transform.origin + \
-							target_position) - \
+							motion) - \
 							collision_shape.global_transform.origin \
-							if current_world else target_position
+							if current_world else motion
 					)
 
 					var shape: Shape2D = collision_shape.shape
@@ -156,83 +138,111 @@ func _get_current_collider() -> YumeCharacter:
 
 	return null
 
-func _move() -> void:
+
+func _move(motion: Vector2, ground_result: Dictionary) -> void:
 	var tween: Tween = create_tween()
 
 	tween.tween_method(
 			func (value: Vector2) -> void:
 				position = value.round()
-	, position, position + target_position, 0.25 / speed)
+	, position, position + motion, 0.25 / speed)
 
 	for collision_shape: CollisionShape2D in collision_shapes:
-		collision_shape.position += target_position
+		collision_shape.position += motion
 
 		tween.parallel()
 
 		tween.tween_property(collision_shape, "position",
-				-target_position, 0.25 / speed).as_relative()
+				-motion, 0.25 / speed).as_relative()
 
 	await tween.finished
 
-func _update_detectors(direction: Direction) -> void:
-	collision_detector.collision_mask = collision_mask
-	surface_detector.collision_mask = collision_mask >> 1
-	target_position = DIRECTIONS[direction] * tile_size
 
-	if current_world:
-		collision_detector.global_position = current_world.wrap_around_world(
-			global_position + target_position) - target_position
-	else:
-		collision_detector.global_position = global_position
+func collide_point(motion: Vector2, mask: int = collision_mask) -> Dictionary:
+	var parameters := PhysicsPointQueryParameters2D.new()
+	parameters.collision_mask = mask
+	parameters.exclude = [get_rid()]
 
-	collision_detector.target_position = target_position
-	collision_detector.force_raycast_update()
-	surface_detector.global_position = collision_detector.global_position
-	surface_detector.target_position = target_position
-	surface_detector.force_raycast_update()
-	var ground: Object = surface_detector.get_collider()
+	var space_state: PhysicsDirectSpaceState2D = (
+			get_world_2d().direct_space_state)
 
-	if ground is TileMapLayer and can_use_stairs:
-		var current_tile: Vector2i = ground.local_to_map(global_position + target_position)
+	for collision_shape: CollisionShape2D in collision_shapes:
+		if current_world:
+			parameters.position = (current_world.wrap_around_world(
+					collision_shape.global_position + motion))
+		else:
+			parameters.position = (
+					collision_shape.global_position + motion)
+
+		var result: Array[Dictionary] = space_state.intersect_point(
+				parameters, 1)
+
+		if result:
+			result[0]["position"] = parameters.position
+			return result[0]
+
+	return {}
+
+
+func collide_ray(offset_and_motion: PackedVector2Array,
+		mask: int = collision_mask) -> Dictionary:
+
+	var offset: Vector2 = offset_and_motion[0]
+	var motion: Vector2 = offset_and_motion[1]
+	var parameters := PhysicsRayQueryParameters2D.new()
+	parameters.collision_mask = mask
+	parameters.exclude = [get_rid()]
+	parameters.hit_from_inside = true
+
+	var space_state: PhysicsDirectSpaceState2D = (
+			get_world_2d().direct_space_state)
+
+	# Check collisions for each collision shape individually.
+	for collision_shape: CollisionShape2D in collision_shapes:
+		var result: Dictionary = {}
+		var to: Vector2 = collision_shape.global_position + motion
+		parameters.from = collision_shape.global_position + offset
 
 		if current_world:
-			current_tile = ground.local_to_map(current_world.wrap_around_world(global_position + target_position))
+			# Wrap the ray to ensure that `parameters.from` is within bounds.
+			parameters.from = current_world.wrap_around_world(parameters.from)
+			to = parameters.from + motion - offset
 
-		var tile_data: TileData = ground.get_cell_tile_data(current_tile)
+			# Check if ray is intersecting with bounds.
+			var intersection: Variant = (
+					current_world.intersect_segment_with_bounds(
+					parameters.from, to)
+			)
 
-		if tile_data:
-			if tile_data.has_custom_data("stair"):
-				match tile_data.get_custom_data("stair"):
-					# \-shaped stairs; horizontal movement.
-					1, 5 when direction & HORIZONTAL:
-						target_position += Vector2(0.0, target_position.x)
-						_update_detector_positions(Vector2(0.0, target_position.x))
+			if intersection == null:
+				parameters.to = to
+				result = space_state.intersect_ray(parameters)
 
-					# /-shaped stairs; horizontal movement.
-					2, 6 when direction & HORIZONTAL:
-						target_position -= Vector2(0.0, target_position.x)
-						_update_detector_positions(-Vector2(0.0, target_position.x))
+				if result:
+					return result
 
-					# \-shaped stairs; vertical movement.
-					3, 5 when direction & VERTICAL:
-						target_position += Vector2(target_position.y, 0.0)
-						_update_detector_positions(Vector2(target_position.y, 0.0))
+			# If ray is intersecting with bounds, break it down into two parts.
+			# First part: within bounds, second part: out of bounds. Then wrap
+			# the second part and check for collisions for each part.
+			else:
+				parameters.to = intersection
+				result = space_state.intersect_ray(parameters)
 
-					# /-shaped stairs; vertical movement.
-					4, 6 when direction & VERTICAL:
-						target_position -= Vector2(target_position.y, 0.0)
-						_update_detector_positions(-Vector2(target_position.y, 0.0))
+				if result:
+					return result
 
-		collision_detector.force_raycast_update()
-		surface_detector.force_raycast_update()
+				# Hack for `@GlobalScope.wrap`'s `max` exclusiveness.
+				parameters.from = current_world.wrap_around_world(
+						intersection + motion) - motion
 
-func _update_detector_positions(target_vector: Vector2) -> void:
-	if current_world:
-		collision_detector.global_position = current_world.wrap_around_world(global_position + target_position + target_vector) - target_position
-	else:
-		collision_detector.global_position = global_position + target_vector
+				parameters.to = current_world.wrap_around_world(to)
+				result = space_state.intersect_ray(parameters)
 
-	surface_detector.global_position = collision_detector.global_position
+				if result:
+					return result
+
+	return {}
+
 
 func face(what: Vector2) -> Direction:
 	var closest: Vector2 = global_position
@@ -259,27 +269,79 @@ func face(what: Vector2) -> Direction:
 	else:
 		return Direction.LEFT
 
-func move(direction: Direction, respect_collisions: bool = true) -> void:
-	if respect_collisions:
-		_update_detectors(direction)
-		var collider: Object = collision_detector.get_collider()
 
-		if collider:
+func get_offset_and_motion(direction: Direction) -> PackedVector2Array:
+	var offset := Vector2.ZERO
+	var motion: Vector2 = DIRECTIONS[direction] * tile_size
+
+	if not can_use_stairs:
+		return [offset, motion]
+
+	var result: Dictionary = collide_point(motion, collision_mask >> 1)
+
+	if result:
+		var ground: Object = result.collider
+
+		if ground is TileMapLayer:
+			var current_tile: Vector2i = ground.local_to_map(result.position)
+			var tile_data: TileData = ground.get_cell_tile_data(current_tile)
+
+			if tile_data:
+				if tile_data.has_custom_data("stair"):
+					match tile_data.get_custom_data("stair"):
+						# \-shaped stairs; horizontal movement.
+						1, 5 when direction & HORIZONTAL:
+							motion.y += motion.x
+							offset += Vector2(0.0, motion.x)
+
+						# /-shaped stairs; horizontal movement.
+						2, 6 when direction & HORIZONTAL:
+							motion.y -= motion.x
+							offset += Vector2(0.0, -motion.x)
+
+						# \-shaped stairs; vertical movement.
+						3, 5 when direction & VERTICAL:
+							motion.x += motion.y
+							offset += Vector2(motion.y, 0.0)
+
+						# /-shaped stairs; vertical movement.
+						4, 6 when direction & VERTICAL:
+							motion.x -= motion.y
+							offset += Vector2(-motion.y, 0.0)
+
+	return [offset, motion]
+
+
+func move(direction: Direction,
+		offset_and_motion: PackedVector2Array = get_offset_and_motion(
+		direction), respect_collisions: bool = true) -> void:
+
+	var motion: Vector2 = offset_and_motion[1]
+	var result: Dictionary = {}
+
+	if respect_collisions:
+		result = collide_ray(offset_and_motion, collision_mask)
+
+		if result:
+			var collider: Object = result.collider
+
 			if collider is YumeInteractable:
 				collider.body_touched.emit(self)
 
 			return
 
-		var ground: Object = surface_detector.get_collider()
+		result = collide_point(motion, collision_mask >> 1)
 
-		if ground:
+		if result:
+			var ground: Object = result.collider
+
 			if ground is YumeInteractable:
 				ground.body_stepped_on.emit.call_deferred(self)
 
 		elif not can_move_in_vacuum:
 			return
 
-		var current_collider: YumeCharacter = _get_current_collider()
+		var current_collider: YumeCharacter = _get_current_collider(motion)
 
 		if current_collider:
 			current_collider.body_touched.emit(self)
@@ -288,32 +350,35 @@ func move(direction: Direction, respect_collisions: bool = true) -> void:
 	for collision_shape: CollisionShape2D in collision_shapes:
 		current_collisions.append(collision_shape)
 
-	wrap_around_world()
+	wrap_around_world(motion)
 	is_busy = true
 	moving = direction
-	await _move()
+	await _move(motion, result)
 	is_busy = false
 	moving = Direction.NULL
 	moved.emit()
 
-func is_colliding(direction: Direction) -> bool:
-	_update_detectors(direction)
 
-	if collision_detector.is_colliding():
+func is_colliding(offset_and_motion: PackedVector2Array) -> bool:
+	if collide_ray(offset_and_motion):
 		return true
 
-	if not (surface_detector.is_colliding() or can_move_in_vacuum):
-		return true
+	var motion: Vector2 = offset_and_motion[1]
 
-	if _get_current_collider():
+	if not can_move_in_vacuum:
+		if collide_point(motion, collision_mask >> 1):
+			return true
+
+	if _get_current_collider(motion):
 		return true
 
 	return false
 
-func wrap_around_world() -> void:
+
+func wrap_around_world(motion: Vector2) -> void:
 	if current_world:
 		var wrapped_position: Vector2 = current_world.wrap_around_world(
-				global_position + target_position) - target_position
+				global_position + motion) - motion
 
 		if global_position != wrapped_position:
 			var previous_position: Vector2 = global_position

--- a/scripts/classes/yume_character.gd
+++ b/scripts/classes/yume_character.gd
@@ -101,6 +101,30 @@ func _move(motion: Vector2, ground_result: Dictionary) -> void:
 	await tween.finished
 
 
+func collide(offset_and_motion: PackedVector2Array,
+		mask: int = collision_mask) -> Dictionary:
+
+	# Check collisions for each collision shape individually.
+	for i: int in get_shape_owners():
+		var shape_owner: Object = shape_owner_get_owner(i)
+
+		var target_position: Vector2 = (
+				shape_owner.global_position + offset_and_motion[1])
+
+		if current_world:
+			target_position = current_world.wrap_around_world(target_position)
+
+		Game.collision_network.validate_tile(target_position)
+
+		var collider: CollisionObject2D = Game.collision_network.collide(
+				self, target_position, mask)
+
+		if collider:
+			return { "collider": collider }
+
+	return collide_ray(offset_and_motion, mask)
+
+
 func collide_point(motion: Vector2, mask: int = collision_mask) -> Dictionary:
 	var parameters := PhysicsPointQueryParameters2D.new()
 	parameters.collision_mask = mask
@@ -143,9 +167,6 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 	var space_state: PhysicsDirectSpaceState2D = (
 			get_world_2d().direct_space_state)
 
-	var network_collider: CollisionObject2D = null
-	Game.collision_network.update()
-
 	# Check collisions for each collision shape individually.
 	for i: int in get_shape_owners():
 		var result: Dictionary = {}
@@ -171,12 +192,6 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 				if result:
 					return result
 
-				network_collider = Game.collision_network.collide(
-						self, parameters.from, parameters.to)
-
-				if network_collider:
-					return Dictionary({ "collider": network_collider })
-
 			# If ray is intersecting with bounds, break it down into two parts.
 			# First part: within bounds, second part: out of bounds. Then wrap
 			# the second part and check for collisions for each part.
@@ -186,12 +201,6 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 
 				if result:
 					return result
-
-				network_collider = Game.collision_network.collide(
-						self, parameters.from, parameters.to)
-
-				if network_collider:
-					return Dictionary({ "collider": network_collider })
 
 				# Hack for `@GlobalScope.wrap`'s `max` exclusiveness.
 				parameters.from = current_world.wrap_around_world(
@@ -203,24 +212,12 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 				if result:
 					return result
 
-				network_collider = Game.collision_network.collide(
-						self, parameters.from, parameters.to)
-
-				if network_collider:
-					return Dictionary({ "collider": network_collider })
-
 		else:
 			parameters.to = to
 			result = space_state.intersect_ray(parameters)
 
 			if result:
 				return result
-
-			network_collider = Game.collision_network.collide(
-					self, parameters.from, to)
-
-			if network_collider:
-				return Dictionary({ "collider": network_collider })
 
 	return {}
 
@@ -301,7 +298,7 @@ func move(direction: Direction,
 	var result: Dictionary = {}
 
 	if respect_collisions:
-		result = collide_ray(offset_and_motion, collision_mask)
+		result = collide(offset_and_motion)
 
 		if result:
 			var collider: Object = result.collider
@@ -322,13 +319,8 @@ func move(direction: Direction,
 		elif not can_move_in_vacuum:
 			return
 
-	else:
-		Game.collision_network.update()
-
-	for i: int in get_shape_owners():
-		Game.collision_network.peers.append(shape_owner_get_owner(i))
-
-	wrap_around_world(motion)
+	Game.collision_network.free_tile(self, global_position)
+	Game.collision_network.occupy_tile(self, wrap_around_world(motion) + motion)
 	is_busy = true
 	moving = direction
 	await _move(motion, result)
@@ -338,7 +330,7 @@ func move(direction: Direction,
 
 
 func is_colliding(offset_and_motion: PackedVector2Array) -> bool:
-	if collide_ray(offset_and_motion):
+	if collide(offset_and_motion):
 		return true
 
 	if not can_move_in_vacuum:
@@ -348,7 +340,7 @@ func is_colliding(offset_and_motion: PackedVector2Array) -> bool:
 	return false
 
 
-func wrap_around_world(motion: Vector2) -> void:
+func wrap_around_world(motion: Vector2) -> Vector2:
 	if current_world:
 		var wrapped_position: Vector2 = current_world.wrap_around_world(
 				global_position + motion) - motion
@@ -357,6 +349,10 @@ func wrap_around_world(motion: Vector2) -> void:
 			var previous_position: Vector2 = global_position
 			global_position = wrapped_position
 			wrapped.emit(previous_position)
+
+		return wrapped_position
+
+	return global_position
 
 func get_next_direction(direction: Direction) -> Direction:
 	match direction:

--- a/scripts/classes/yume_character.gd
+++ b/scripts/classes/yume_character.gd
@@ -56,8 +56,6 @@ var current_world: YumeWorld = null
 ## Direction the character is moving.
 var moving := Direction.NULL
 
-var collision_shapes: Array[CollisionShape2D] = []
-
 static var current_collisions: Array[CollisionShape2D] = []
 
 static var collisions_last_checked: int = 0
@@ -67,18 +65,6 @@ signal moved
 
 ## Emitted when the character has been wrapped around [member current_world].
 signal wrapped(previous_position: Vector2)
-
-func _init() -> void:
-	var on_child_entered_tree: Callable = func (node: Node):
-		if node is CollisionShape2D:
-			collision_shapes.append(node)
-
-	var on_child_exiting_tree: Callable = func (node: Node):
-		if node is CollisionShape2D:
-			collision_shapes.erase(node)
-
-	child_entered_tree.connect(on_child_entered_tree)
-	child_exiting_tree.connect(on_child_exiting_tree)
 
 
 func _notification(what: int) -> void:
@@ -110,23 +96,25 @@ func _get_current_collider(motion: Vector2) -> YumeCharacter:
 			if collision_mask & current_collision_shape_parent.collision_layer \
 					and not current_collision_shape.disabled:
 
-				for collision_shape: CollisionShape2D in collision_shapes:
+				for i: int in get_shape_owners():
+					var shape_owner: Object = shape_owner_get_owner(i)
+
 					var target_origin: Vector2 = (
 							current_world.wrap_around_world(
-							collision_shape.global_transform.origin + \
+							shape_owner.global_transform.origin + \
 							motion) - \
-							collision_shape.global_transform.origin \
+							shape_owner.global_transform.origin \
 							if current_world else motion
 					)
 
-					var shape: Shape2D = collision_shape.shape
 					var current_shape: Shape2D = current_collision_shape.shape
 					var target_transform := \
-							Transform2D(collision_shape.global_transform)
+							Transform2D(shape_owner.global_transform)
 
 					target_transform.origin += target_origin
 
-					if not shape.collide_and_get_contacts(target_transform,
+					if not shape_owner_get_shape(i, 0).collide_and_get_contacts(
+							target_transform,
 							current_shape,
 							current_collision_shape.global_transform) \
 							.is_empty():
@@ -147,12 +135,13 @@ func _move(motion: Vector2, ground_result: Dictionary) -> void:
 				position = value.round()
 	, position, position + motion, 0.25 / speed)
 
-	for collision_shape: CollisionShape2D in collision_shapes:
-		collision_shape.position += motion
+	for i: int in get_shape_owners():
+		var shape_owner: Object = shape_owner_get_owner(i)
+		shape_owner.position += motion
 
 		tween.parallel()
 
-		tween.tween_property(collision_shape, "position",
+		tween.tween_property(shape_owner, "position",
 				-motion, 0.25 / speed).as_relative()
 
 	await tween.finished
@@ -166,13 +155,16 @@ func collide_point(motion: Vector2, mask: int = collision_mask) -> Dictionary:
 	var space_state: PhysicsDirectSpaceState2D = (
 			get_world_2d().direct_space_state)
 
-	for collision_shape: CollisionShape2D in collision_shapes:
+	# Check collisions for each collision shape individually.
+	for i: int in get_shape_owners():
+		var shape_owner: Object = shape_owner_get_owner(i)
+
 		if current_world:
 			parameters.position = (current_world.wrap_around_world(
-					collision_shape.global_position + motion))
+					shape_owner.global_position + motion))
 		else:
 			parameters.position = (
-					collision_shape.global_position + motion)
+					shape_owner.global_position + motion)
 
 		var result: Array[Dictionary] = space_state.intersect_point(
 				parameters, 1)
@@ -198,10 +190,11 @@ func collide_ray(offset_and_motion: PackedVector2Array,
 			get_world_2d().direct_space_state)
 
 	# Check collisions for each collision shape individually.
-	for collision_shape: CollisionShape2D in collision_shapes:
+	for i: int in get_shape_owners():
 		var result: Dictionary = {}
-		var to: Vector2 = collision_shape.global_position + motion
-		parameters.from = collision_shape.global_position + offset
+		var shape_owner: Object = shape_owner_get_owner(i)
+		var to: Vector2 = shape_owner.global_position + motion
+		parameters.from = shape_owner.global_position + offset
 
 		if current_world:
 			# Wrap the ray to ensure that `parameters.from` is within bounds.
@@ -347,8 +340,8 @@ func move(direction: Direction,
 			current_collider.body_touched.emit(self)
 			return
 
-	for collision_shape: CollisionShape2D in collision_shapes:
-		current_collisions.append(collision_shape)
+	for i: int in get_shape_owners():
+		current_collisions.append(shape_owner_get_owner(i))
 
 	wrap_around_world(motion)
 	is_busy = true

--- a/scripts/classes/yume_humanoid.gd
+++ b/scripts/classes/yume_humanoid.gd
@@ -37,28 +37,27 @@ var last_step: int = STEP_LEFT
 func _force_animation_update() -> void:
 	pass
 
-func _move() -> void:
+
+func _move(motion: Vector2, ground_result: Dictionary) -> void:
 	footstep_sound = (current_world.default_footstep_sound if current_world
 			else load("res://resources/sounds/step.wav"))
 
-	var ground: Object = surface_detector.get_collider()
+	if ground_result:
+		var ground: Object = ground_result.collider
 
-	if ground is TileMapLayer:
-		var current_tile: Vector2i = (ground.local_to_map(
-			current_world.wrap_around_world(surface_detector.global_position +
-			surface_detector.target_position)) if current_world else
-			ground.local_to_map(surface_detector.global_position +
-			surface_detector.target_position))
+		if ground is TileMapLayer:
+			var current_tile: Vector2i = ground.local_to_map(
+					ground_result.position)
 
-		var tile_data: TileData = ground.get_cell_tile_data(current_tile)
-		footstep_sound = get_tile_footstep_sound(tile_data)
+			var tile_data: TileData = ground.get_cell_tile_data(current_tile)
+			footstep_sound = get_tile_footstep_sound(tile_data)
 
-	elif ground is YumeInteractable:
-		footstep_sound = get_footstep_sound(ground.surface)
+		elif ground is YumeInteractable:
+			footstep_sound = get_footstep_sound(ground.surface)
 
 	last_step = !last_step
 
-	await super()
+	await super(motion, ground_result)
 
 func get_footstep_sound(ground: Surface) -> AudioStream:
 	match ground:

--- a/scripts/classes/yume_player.gd
+++ b/scripts/classes/yume_player.gd
@@ -134,8 +134,8 @@ func _input(event: InputEvent) -> void:
 		mapshot.save_png(Game.MAPSHOTS_DIRECTORY.path_join(Game.get_timestamp() + ".png"))
 
 
-func _move() -> void:
-	await super()
+func _move(motion: Vector2, ground_result: Dictionary) -> void:
+	await super(motion, ground_result)
 	Game.persistent_data.steps_taken += 1
 
 
@@ -155,12 +155,14 @@ func equip(effect: Effect = Effect.DEFAULT) -> void:
 func interact() -> void:
 	if not is_sitting and is_inside_tree():
 		await get_tree().physics_frame
-		_update_detectors(facing)
-		var collider: Object = collision_detector.get_collider()
+		var result: Dictionary = collide_ray(get_offset_and_motion(facing))
 
-		if collider is YumeInteractable:
-			collider.body_interacted.emit(self)
-			collider.body_touched.emit(self)
+		if result:
+			var collider: Object = result.collider
+
+			if collider is YumeInteractable:
+				collider.body_interacted.emit(self)
+				collider.body_touched.emit(self)
 
 
 ## Play the cheek pinching animation. Wakes up the character, if is dreaming.

--- a/scripts/classes/yume_player.gd
+++ b/scripts/classes/yume_player.gd
@@ -154,7 +154,7 @@ func equip(effect: Effect = Effect.DEFAULT) -> void:
 func interact() -> void:
 	if not is_sitting and is_inside_tree():
 		await get_tree().physics_frame
-		var result: Dictionary = collide_ray(get_offset_and_motion(facing))
+		var result: Dictionary = collide(get_offset_and_motion(facing))
 
 		if result:
 			var collider: Object = result.collider

--- a/scripts/classes/yume_player.gd
+++ b/scripts/classes/yume_player.gd
@@ -56,7 +56,6 @@ signal cancel_key_held()
 signal equipped(effect: Effect)
 
 func _init() -> void:
-	super()
 	set_process(true)
 
 func _notification(what: int) -> void:

--- a/scripts/classes/yume_world.gd
+++ b/scripts/classes/yume_world.gd
@@ -273,6 +273,49 @@ func _on_child_exiting_tree(node: Node):
 		if parallaxes.has(node):
 			parallaxes.erase(node)
 
+
+func intersect_segment_with_bounds(from: Vector2, to: Vector2) -> Variant:
+	if not bounds.has_area():
+		return null
+
+	var lines: Array[PackedVector2Array] = []
+
+	match loop:
+		"All Sides":
+			lines = [[bounds.position, Vector2.RIGHT],
+				[bounds.position, Vector2.DOWN],
+				[bounds.end, Vector2.RIGHT],
+				[bounds.end, Vector2.DOWN]]
+
+		"Horizontally":
+			lines = [[bounds.position, Vector2.DOWN],
+				[bounds.end, Vector2.DOWN]]
+
+		"Vertically":
+			lines = [[bounds.position, Vector2.RIGHT],
+				[bounds.end, Vector2.RIGHT]]
+
+		_:
+			return null
+
+	var direction: Vector2 = to - from
+
+	for line: PackedVector2Array in lines:
+		var intersection: Variant = Geometry2D.line_intersects_line(
+				line[0], line[1], from, direction)
+
+		if intersection == null:
+			continue
+
+		var t: float = (intersection - from).dot(
+				direction) / (direction).length_squared()
+
+		if t >= 0.0 and t <= 1.0:
+			return intersection
+
+	return null
+
+
 func wrap_around_world(value: Vector2) -> Vector2:
 	if bounds.has_area():
 		match loop:

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -107,6 +107,8 @@ func _ready() -> void:
 
 	scene_tree.scene_changed.connect(
 			func () -> void:
+				collision_network.clear()
+
 				var current_scene: Node = scene_tree.current_scene
 
 				if current_scene_load_state != SceneLoadState.FROM_SAVE_FILE:
@@ -413,45 +415,47 @@ class Data:
 
 
 class TileBasedCollisionNetwork:
-	var last_checked: int = 0
-	var peers: Array[CollisionShape2D] = []
+	var _occupied_tiles: Dictionary[Vector2, Array] = {}
 
 
-	func collide(object: CollisionObject2D,
-			from: Vector2, to: Vector2) -> CollisionObject2D:
+	func clear() -> void:
+		_occupied_tiles.clear()
 
-		for peer: CollisionShape2D in peers:
-			var peer_parent: CollisionObject2D = peer.get_parent()
 
-			if (object.collision_mask & peer_parent.collision_layer == 0 or
-					peer.disabled):
+	func collide(object: CollisionObject2D, tile: Vector2,
+			mask = object.collision_mask) -> CollisionObject2D:
 
-				continue
+		if not _occupied_tiles.has(tile):
+			return null
 
-			var rect: Rect2 = peer.shape.get_rect()
-
-			var polygon: PackedVector2Array = [
-				peer.global_position + rect.position,
-
-				Vector2(peer.global_position.x + rect.end.x,
-						peer.global_position.y + rect.position.y),
-
-				peer.global_position + rect.end,
-
-				Vector2(peer.global_position.x + rect.position.x,
-						peer.global_position.y + rect.end.y)]
-
-			if Geometry2D.intersect_polyline_with_polygon(
-					PackedVector2Array([from, to]), polygon):
-
-					return peer_parent
+		for collider: CollisionObject2D in _occupied_tiles[tile]:
+			if mask & collider.collision_layer:
+				return collider
 
 		return null
 
 
-	func update() -> void:
-		var physics_frames: int = Engine.get_physics_frames()
+	func free_tile(object: CollisionObject2D, tile: Vector2) -> void:
+		if not _occupied_tiles.has(tile):
+			return
 
-		if last_checked != physics_frames:
-			last_checked = physics_frames
-			peers.clear()
+		if _occupied_tiles[tile].size() == 1:
+			_occupied_tiles.erase(tile)
+		else:
+			_occupied_tiles[tile].erase(object)
+
+
+	func occupy_tile(object: CollisionObject2D, tile: Vector2) -> void:
+		if not _occupied_tiles.has(tile):
+			_occupied_tiles[tile] = []
+
+		_occupied_tiles[tile].append(object)
+
+
+	func validate_tile(tile: Vector2) -> void:
+		if not _occupied_tiles.has(tile):
+			return
+
+		for entry: Variant in _occupied_tiles[tile]:
+			if entry == null:
+				_occupied_tiles[tile].erase(entry)

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -38,7 +38,9 @@ const MAPSHOTS_DIRECTORY: String = "user://mapshots"
 
 @onready var mouse_timer: Timer = get_node("MouseTimer")
 
-var current_scene_load_state: SceneLoadState = SceneLoadState.UNKNOWN
+var collision_network := TileBasedCollisionNetwork.new()
+
+var current_scene_load_state := SceneLoadState.UNKNOWN
 
 var key_hold_time: float = 0.5
 
@@ -408,3 +410,48 @@ class Data:
 			dictionary[properties[i].name] = get(properties[i].name)
 
 		return dictionary
+
+
+class TileBasedCollisionNetwork:
+	var last_checked: int = 0
+	var peers: Array[CollisionShape2D] = []
+
+
+	func collide(object: CollisionObject2D,
+			from: Vector2, to: Vector2) -> CollisionObject2D:
+
+		for peer: CollisionShape2D in peers:
+			var peer_parent: CollisionObject2D = peer.get_parent()
+
+			if (object.collision_mask & peer_parent.collision_layer == 0 or
+					peer.disabled):
+
+				continue
+
+			var rect: Rect2 = peer.shape.get_rect()
+
+			var polygon: PackedVector2Array = [
+				peer.global_position + rect.position,
+
+				Vector2(peer.global_position.x + rect.end.x,
+						peer.global_position.y + rect.position.y),
+
+				peer.global_position + rect.end,
+
+				Vector2(peer.global_position.x + rect.position.x,
+						peer.global_position.y + rect.end.y)]
+
+			if Geometry2D.intersect_polyline_with_polygon(
+					PackedVector2Array([from, to]), polygon):
+
+					return peer_parent
+
+		return null
+
+
+	func update() -> void:
+		var physics_frames: int = Engine.get_physics_frames()
+
+		if last_checked != physics_frames:
+			last_checked = physics_frames
+			peers.clear()

--- a/scripts/props/pushable.gd
+++ b/scripts/props/pushable.gd
@@ -16,14 +16,19 @@
 
 extends YumeCharacter
 
-func _init() -> void:
-	super()
-	body_touched.connect(_on_body_touched)
 
-func _on_body_touched(body: Node2D):
-	if body is YumeCharacter and not is_busy:
-		var direction: Direction = body.face(global_position)
+func _ready() -> void:
+	body_touched.connect(
+			func (body: Node2D) -> void:
+				if body is YumeCharacter and not is_busy:
+					var direction: Direction = body.face(global_position)
 
-		if not is_colliding(direction):
-			move(direction)
-			body.move(direction)
+					var offset_and_motion: PackedVector2Array = (
+							get_offset_and_motion(direction))
+
+					if not is_colliding(offset_and_motion):
+						move(direction, offset_and_motion, false)
+
+						body.move(direction, body.get_offset_and_motion(
+								direction), false)
+	)


### PR DESCRIPTION
This PR completely reworks collision logic for YumeCharacter to ensure it is correct for every edge case.

* Collision checks are now performed by querying PhysicsDirectSpaceState2D instead of relying on RayCast2Ds. This change makes the scene tree cleaner and allows to make collisions checks with different collision masks.

* `target_position` has been replaced with `get_offset_and_motion()` which returns the offset from the starting position and the motion vector. `offset` and `motion` are passed as function arguments instead of being a file scope variable.

* `_move()` now has `ground_result` argument to avoid duplicated calculations.

* Collisions checks are now performed by calling `collide()`. `collide_point()` and `collide_ray()` are also used internally.

* Checking collisions on the edges of YumeWorlds' `bounds` has been rewritten and ensured that they work correctly.

* `YumeCharacter._get_current_collider()` has been replaced with `Game.collision_network` with reworked collision system for tile-based movement. This also allows to create nodes using tile-based movement independent of YumeCharacter.